### PR TITLE
为舞萌 DX 数据表格添加封面列

### DIFF
--- a/web/src/components/ChartTable.vue
+++ b/web/src/components/ChartTable.vue
@@ -12,6 +12,14 @@
     loading-text="加载中……"
     no-results-text="没有符合条件的条目"
   >
+    <template #item.cover="{ item }">
+      <v-img
+        :src="`https://www.diving-fish.com/covers/${getCoverPathById(item.song_id)}`"
+        width="72px"
+        class="rounded"
+        contain
+      ></v-img>
+    </template>
     <template #item.title="{ item }">
       <v-tooltip top :disabled="!music_data_dict[item.song_id]">
         <template v-slot:activator="{ on, attrs }">
@@ -197,6 +205,11 @@ export default {
     },
   },
   methods: {
+    getCoverPathById: function (songId) {
+      let i = parseInt(songId);
+      if (i > 10000) i -= 10000;
+      return (i + "").padStart(4, '0') + ".png";
+    },
     getLevel(index) {
       return ["#22bb5b", "#fb9c2d", "#f64861", "#9e45e2", "#ba67f8"][index];
     },

--- a/web/src/components/ProSettings.vue
+++ b/web/src/components/ProSettings.vue
@@ -300,6 +300,7 @@ export default {
       headers: [],
       headers_default: [
         { text: "排名", value: "rank" },
+        { text: "封面", value: "cover", sortable: false},
         { text: "乐曲名", value: "title" },
         { text: "难度", value: "level", sortable: false },
         { text: "定数", value: "ds" },
@@ -310,6 +311,7 @@ export default {
       ],
       headers_items: [
         { text: "排名", value: "rank" },
+        { text: "封面", value: "cover", sortable: false},
         { text: "乐曲名", value: "title" },
         { text: "难度", value: "level", sortable: false },
         { text: "定数", value: "ds" },
@@ -322,6 +324,7 @@ export default {
       ],
       headers_values: [
         "rank",
+        "cover",
         "title",
         "level",
         "ds",

--- a/web/src/components/ProSettings.vue
+++ b/web/src/components/ProSettings.vue
@@ -300,7 +300,6 @@ export default {
       headers: [],
       headers_default: [
         { text: "排名", value: "rank" },
-        { text: "封面", value: "cover", sortable: false},
         { text: "乐曲名", value: "title" },
         { text: "难度", value: "level", sortable: false },
         { text: "定数", value: "ds" },

--- a/web/src/pages/MainPage.vue
+++ b/web/src/pages/MainPage.vue
@@ -539,6 +539,7 @@ export default {
       chart_combo: {},
       headers: [
         { text: "排名", value: "rank" },
+        { text: "封面", value: "cover", sortable: false},
         { text: "乐曲名", value: "title" },
         { text: "难度", value: "level", sortable: false },
         { text: "定数", value: "ds" },


### PR DESCRIPTION
有时候看名字不认得是哪首歌。。。默认隐藏封面列（省流）

![image](https://user-images.githubusercontent.com/29042285/219881168-b39497c6-fa47-46a9-bf7b-3126c2d19ae9.png)

![image](https://user-images.githubusercontent.com/29042285/219881185-c34af7a9-0ae4-466f-a8d7-e104a656d59a.png)

另外建议封面的 `cache-control` 的 `max-age` 可以改成 `-1`，不过期浏览器缓存：

![image](https://user-images.githubusercontent.com/29042285/219881243-793126db-f3c0-4c5f-aa86-01e83eaaa588.png)

