### PR TITLE
[fix] show full chain

### DIFF
--- a/web/src/components/ChuniTable.vue
+++ b/web/src/components/ChuniTable.vue
@@ -93,6 +93,7 @@ export default {
     getName(str) {
       const map = {
         fullcombo: "FC",
+        fullchain: "FULL CHAIN",
         alljustice: "AJ",
       };
       return map[str];

--- a/web/src/components/ProSettingsChuni.vue
+++ b/web/src/components/ProSettingsChuni.vue
@@ -88,6 +88,7 @@ export default {
       fc_filter_items: [
         { text: "空", value: 0},
         { text: "FC", value: "fullcombo"},
+        { text: "FULL CHAIN", value: "fullchain"},
         { text: "AJ", value: "alljustice"},
       ],
       level_filter_items: [
@@ -211,7 +212,7 @@ export default {
       return "grey";
     },
     reset() {
-      this.fc_filter = [0, "fullcombo", "alljustice"];
+      this.fc_filter = [0, "fullcombo","fullchain" , "alljustice"];
       this.level_filter = [0, 1, 2, 3, 4, 5];
       this.rate_filter = ["sssp", "sss", "ssp", "ss", "sp", "s", "aaa", "aa", "a", "bbb", "bb", "b", "c", "d"];
     },


### PR DESCRIPTION
修复中二成绩表前端不显示且无法筛选 FULL CHAIN 结果的问题，由于首字母与 FC 相同所以使用了完整拼写以进行区分。

同时 FULL CHAIN 在游戏设定上属于 FC 的范畴，但查分器数据库将其合并为 FC 状态并独立与 FC，此问题需要对后端进行优化。