### PR TITLE
添加按乐曲分类导入 命令行参数-genre

### DIFF
--- a/proxy/cmd/maimaidx-prober-proxy/config.go
+++ b/proxy/cmd/maimaidx-prober-proxy/config.go
@@ -22,6 +22,7 @@ type config struct {
 	Mode        string   `json:"mode,omitempty"`
 	MaiDiffs    []string `json:"mai_diffs,omitempty"`
 	MaiIntDiffs []int
+	Genre       bool
 }
 
 func (c *config) getWorkingMode() workingMode {

--- a/proxy/cmd/maimaidx-prober-proxy/main.go
+++ b/proxy/cmd/maimaidx-prober-proxy/main.go
@@ -29,6 +29,7 @@ func main() {
 	addr := flag.String("addr", ":8033", "proxy listen address")
 	configPath := flag.String("config", "config.json", "path to config.json file")
 	noEditGlobalProxy := flag.Bool("no-edit-global-proxy", false, "don't edit the global proxy settings")
+	fetchAsGenre := flag.Bool("genre", false, "fetch maimai data as each music-genre")
 	networkTimeout := flag.Int("timeout", 30, "timeout when connect to servers")
 	maiDiffStr := flag.String("mai-diffs", "", "mai diffs to import")
 	flag.Parse()
@@ -62,6 +63,7 @@ func main() {
 	if err != nil {
 		commandFatal(err)
 	}
+	cfg.Genre = *fetchAsGenre
 
 	apiClient, err := newProberAPIClient(&cfg, *networkTimeout)
 	if err != nil {


### PR DESCRIPTION
添加命令行参数 -genre，可以按照不同的分类导入maimai记录，每次请求导入一个分类。
用于减少单次请求大小，在华立服务器变土豆时可以提高导入成功率（