### PR TITLE
调整配置读取方式，优化代理启动体验

### DIFF
--- a/proxy/cmd/maimaidx-prober-proxy/main.go
+++ b/proxy/cmd/maimaidx-prober-proxy/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"path/filepath"
 
 	"github.com/elazarl/goproxy"
 )
@@ -28,7 +29,9 @@ func main() {
 
 	flagSet.Bool("v", false, "should every proxy request be logged to stdout")
 	flagSet.String("addr", ":8033", "proxy listen address")
-	configPath := flagSet.String("config", "config.json", "path to config.json file")
+	ex, _ := os.Executable()
+	exPath := filepath.Dir(ex)
+	configPath := flagSet.String("config", exPath+"/config.json", "path to config.json file")
 	flagSet.Bool("no-edit-global-proxy", false, "don't edit the global proxy settings")
 	flagSet.Bool("slice", false, "using more parts to import records")
 	flagSet.Int("timeout", 30, "timeout when connect to servers")


### PR DESCRIPTION
目前代理程序是从当前工作目录读配置文件的，在双击打开或者Windows快捷方式打开的场景下没有问题，但是在终端中利用PATH直接运行代理时，cwd不一定是程序目录，此时从程序目录中读配置文件可能会更加合适，同时不影响双击打开的场景。