### PR TITLE
fix: `fullchain`/`fullchain2` has a higher priority than `alljustice`

### DIFF
--- a/database/tools/page_parser.py
+++ b/database/tools/page_parser.py
@@ -79,7 +79,7 @@ def parse_chuni_music_box(div):
         icons = div.find(class_="play_musicdata_icon").find_all(name="img")
         if icons[-1].attrs['src'].find("rank") == -1:
             for icon in icons:
-                if 'alljustice' in icons[-1].attrs['src']:
+                if 'alljustice' in icon.attrs['src']:
                     fc = 'alljustice'
                     break
             else:

--- a/database/tools/page_parser.py
+++ b/database/tools/page_parser.py
@@ -78,7 +78,12 @@ def parse_chuni_music_box(div):
     if div.find(class_="play_musicdata_icon") is not None:
         icons = div.find(class_="play_musicdata_icon").find_all(name="img")
         if icons[-1].attrs['src'].find("rank") == -1:
-            fc = icons[-1].attrs['src'][:-4].split('_')[-1]
+            for icon in icons:
+                if 'alljustice' in icons[-1].attrs['src']:
+                    fc = 'alljustice'
+                    break
+            else:
+                fc = icons[-1].attrs['src'][:-4].split('_')[-1]
     return {"title": title, "score": hs, "fc": fc, "level": level}
     
 


### PR DESCRIPTION
在中二节奏中，`alljustice`是一首歌的最高成就。

然而现有的代码解析时，`fullchain`/`fullchain2`的优先度高于`alljustice`，这导致成绩导入时失去了最高成就，令人沮丧。