### PR TITLE
[fix] #160 修复计算工具按定数计算Rating时部分计算显示结果比实际ra值偏高问题

### DIFF
--- a/web/src/components/Calculators.vue
+++ b/web/src/components/Calculators.vue
@@ -711,7 +711,7 @@ export default {
             more_ra.push({
               ds: ds,
               achievements: ans / 10000,
-              rating: curr_max_ra,
+              rating: new ScoreCoefficient(ans / 10000).ra(ds),
             });
           }
         }


### PR DESCRIPTION
![2025-06-13_191723](https://github.com/user-attachments/assets/5ebb22b1-a1ab-4b49-afd0-10f09b1d0119)
