### PR TITLE
[feature]适配宴谱导入

### DIFF
--- a/.github/workflows/build_go.yml
+++ b/.github/workflows/build_go.yml
@@ -6,6 +6,7 @@ on:
       - "*"
   pull_request:
     types: [labeled]
+  workflow_dispatch:
     
 jobs:
   build:

--- a/page-parser/index.js
+++ b/page-parser/index.js
@@ -122,7 +122,7 @@ const pageToRecordList = function (pageData) {
     '//div[@class="music_name_block t_l f_13 break"]',
     doc
   );
-  const labels = ["basic", "advanced", "expert", "master", "remaster"];
+  const labels = ["basic", "advanced", "expert", "master", "remaster", ""];
   for (const name of names) {
     let title = name.textContent;
     let diffNode = getSibN(name, -6);
@@ -141,9 +141,10 @@ const pageToRecordList = function (pageData) {
     let fcNode = getSibN(name, 8);
     let rateNode = getSibN(name, 10);
 
-    const level_index = labels.indexOf(
+    let level_index = labels.indexOf(
       diffNode.getAttribute("src").match("diff_(.*).png")[1]
     );
+
     if (title == "Link") {
       if (typeNode) {
         dxScore = parseInt(dxScoreNode.textContent.split('/')[1])
@@ -161,7 +162,7 @@ const pageToRecordList = function (pageData) {
     let record_data = {
       title: title,
       level: levelNode.textContent,
-      level_index: level_index,
+      level_index: level_index === 5 ? 0 : level_index,
       type: "",
       achievements: parseFloat(scoreNode.textContent),
       dxScore: parseInt(dxScoreNode.textContent.replace(",", "")),
@@ -196,6 +197,11 @@ const pageToRecordList = function (pageData) {
       if (s == "standard") record_data.type = "SD";
       else record_data.type = "DX";
     }
+
+    if (level_index == 5) {
+      record_data.type = "DX";
+    }
+
     records.push(record_data);
   }
   return records;

--- a/proxy/cmd/maimaidx-prober-proxy/config.go
+++ b/proxy/cmd/maimaidx-prober-proxy/config.go
@@ -80,13 +80,17 @@ func getMaiDiffs(MaiDiffs []string) (diffs []int, err error) {
 		"rem":       4,
 		"remaster":  4,
 		"re:master": 4,
+		"10":        10,
+		"uta":       10,
+		"utage":     10,
 	}
 	if len(MaiDiffs) == 0 {
 		for i := 0; i <= 4; i++ {
 			diffs = append(diffs, i) // 添加元素
 		}
+		diffs = append(diffs, 10)
 	} else {
-		diffList := []string{"Basic", "Advanced", "Expert", "Master", "Re:MASTER"}
+		diffList := []string{"Basic", "Advanced", "Expert", "Master", "Re:MASTER", "", "", "", "", "", "UTAGE"}
 		diffStr := ""
 		for _, diff := range MaiDiffs {
 			if intDiff, exist := maiDiffMap[strings.ToLower(diff)]; exist {

--- a/proxy/cmd/maimaidx-prober-proxy/prober_api.go
+++ b/proxy/cmd/maimaidx-prober-proxy/prober_api.go
@@ -89,7 +89,7 @@ func (c *proberAPIClient) fetchDataMaimai(req0 *http.Request, cookies []*http.Co
 	c.cl.Jar.SetCookies(req0.URL, cookies)
 
 	labels := []string{
-		"Basic", "Advanced", "Expert", "Master", "Re: MASTER",
+		"Basic", "Advanced", "Expert", "Master", "Re: MASTER", "", "", "", "", "", "UTAGE",
 	}
 	versionTags := []string{
 		"V-0", "V-1", "V-2", "V-3", "V-4", "V-5", "V-6", "V-7", "V-8", "V-9", "V-10", "V-11", "V-12", "V-13", "V-15", "V-17", "V-19",


### PR DESCRIPTION
为解析页面和代理工具增加宴谱适配逻辑

数据库中宴谱被统一归类为DX类型#156，可能需要修改，但本PR只是简单的将宴谱全部归类为DX
`update_records`中只有将`level_index`设为0才能成功导入宴谱，本PR将宴谱的`level_index`设为0