### PR TITLE
fix: allow token headers in CORS

### DIFF
--- a/database/app.py
+++ b/database/app.py
@@ -40,7 +40,7 @@ async def startup():
 def cors(environ):
     environ.headers['Access-Control-Allow-Origin'] = '*'
     environ.headers['Access-Control-Allow-Method'] = '*'
-    environ.headers['Access-Control-Allow-Headers'] = 'x-requested-with,content-type'
+    environ.headers['Access-Control-Allow-Headers'] = 'x-requested-with,content-type,import-token'
     if getattr(g, "user", None) is not None and request.method != 'OPTIONS':
         environ.set_cookie('jwt_token', username_encode(g.username), max_age=30 * 86400)
     return environ


### PR DESCRIPTION
This is helpful for developers to access the user's data with import-token on frontend, without passing user's import token to third-party app's backend.

Not adding `developer-token` here, since developer tokens should be always kept secretly in app's backend.