### PR TITLE
Add OAuth support for /query/player

### DIFF
--- a/database/app.py
+++ b/database/app.py
@@ -430,6 +430,25 @@ def oauth_or_login_required(*required_scopes):
     return deco
 
 
+def oauth_optional_required(*required_scopes):
+    """仅当带 Bearer 时才校验，不影响原有公开查询方式。
+
+    带 Bearer 时通过 _auth_by_bearer 进行校验，其他情况下与不带此装饰器时一致。
+    """
+    def deco(f):
+        @wraps(f)
+        async def func(*args, **kwargs):
+            auth = request.headers.get('Authorization', default='')
+            if auth[:7].lower() == 'bearer ':
+                err = await _auth_by_bearer(auth[7:].strip(), required_scopes)
+                if err is not None:
+                    return err
+            return await f(*args, **kwargs)
+        return func
+
+    return deco
+
+
 async def is_developer(token):
     if token == "":
         return False, {"status": "error", "msg": "请先联系水鱼申请开发者token"}, 400

--- a/database/routes/maimai.py
+++ b/database/routes/maimai.py
@@ -8,7 +8,7 @@ https://www.diving-fish.com/api/maimaidxprober/*
 import asyncio
 import time
 from collections import defaultdict
-from app import app, developer_required, login_required, login_or_token_required, oauth_or_login_required, md5, is_developer, chart_stat_updated, scheduler, job_lock
+from app import app, developer_required, login_required, login_or_token_required, oauth_or_login_required, oauth_optional_required, md5, is_developer, chart_stat_updated, scheduler, job_lock
 from apscheduler.triggers.cron import CronTrigger
 from quart import Quart, request, g, make_response
 from tools._jwt import *
@@ -511,29 +511,33 @@ async def getplatelist(player, version: List[Dict]):
 
 
 @app.route("/query/player", methods=['POST'])
+@oauth_optional_required("prober.records.read")
 async def query_player():
     obj = await request.json
-    try:
-        if "qq" in obj:
-            p: Player = await Player.by_qq(obj["qq"])
-        else:
-            username = obj["username"]
-            p: Player = await Player.aio_get(Player.username == username)
-    except Exception:
-        return {
-            "message": "user not exists"
-        }, 400
-    if p.privacy or not p.accept_agreement:
+    if getattr(g, "login_type", None) == 'oauth':
+        p: Player = g.user
+    else:
         try:
-            token = decode(request.cookies['jwt_token'])
-        except KeyError:
-            return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
-        if token == {}:
-            return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
-        if token['exp'] < ts():
-            return {"status": "error", "message": "会话过期"}, 403
-        if token['username'] != obj["username"]:
-            return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
+            if "qq" in obj:
+                p: Player = await Player.by_qq(obj["qq"])
+            else:
+                username = obj["username"]
+                p: Player = await Player.aio_get(Player.username == username)
+        except Exception:
+            return {
+                "message": "user not exists"
+            }, 400
+        if p.privacy or not p.accept_agreement:
+            try:
+                token = decode(request.cookies['jwt_token'])
+            except KeyError:
+                return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
+            if token == {}:
+                return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
+            if token['exp'] < ts():
+                return {"status": "error", "message": "会话过期"}, 403
+            if token['username'] != obj["username"]:
+                return {"status": "error", "message": "已设置隐私或未同意用户协议"}, 403
     if "b50" in obj:
         sd, dx = await get_dx_and_sd_for50(p)
         await compute_ra(p, sd, dx)


### PR DESCRIPTION
目前`/query/player`端点不支持通过OAuth方式查询，对于未来完全放弃QQ号绑定逻辑转而采用OAuth绑定的官Bot来说，每次在用户本人查询b50时都得通过`/player/records`端点拉取完整成绩，将会对服务器造成一定负担，因此可以考虑为该端点加入这一支持